### PR TITLE
Multiple lines per track

### DIFF
--- a/api/app/controllers/api.rb
+++ b/api/app/controllers/api.rb
@@ -72,7 +72,7 @@ class Api < App
 
     last_modified [last_modified_source_feature(@city, type), last_modified_system_or_line(@city)].compact.max
 
-    lines_features_collection(@city, type).to_json
+    formatted_lines_features_collection(@city, type).to_json
   end
 
   get '/editor/:url_name/data' do |url_name|

--- a/api/app/controllers/api.rb
+++ b/api/app/controllers/api.rb
@@ -99,8 +99,10 @@ class Api < App
     @city = City[url_name: url_name]
     changes = JSON.parse(request.body.read, symbolize_names: true)
 
-    changes.each do |change|
-      update_create_or_delete_feature(@city, user, change);
+    DB.transaction do
+      changes.each do |change|
+        update_create_or_delete_feature(@city, user, change);
+      end
     end
 
     status 200

--- a/api/app/helpers/cache_helpers.rb
+++ b/api/app/helpers/cache_helpers.rb
@@ -6,7 +6,11 @@ module CacheHelpers
   def last_modified_source_feature(city, type)
     klass_name = type == 'sections' ? 'Section' : 'Station'
 
-    [features_query(city, type).max(:updated_at), DeletedFeature.where(feature_class: klass_name, city_id: city.id).max(:created_at)].compact.max
+    [
+      features_query(city, type).max(:updated_at),
+      feature_lines_query(city, type).max(:updated_at),
+      DeletedFeature.where(feature_class: klass_name, city_id: city.id).max(:created_at)
+    ].compact.max
   end
 
   def last_modified_system_or_line(city)

--- a/api/app/helpers/city_helpers.rb
+++ b/api/app/helpers/city_helpers.rb
@@ -22,22 +22,19 @@ module CityHelpers
     lengths = {}
     years_range = (city.start_year..DateTime.now.year)
 
-    # FIXME:
-    # These calcs are duplicating kms if the lines share a track
     Section.where(city_id: city.id).each do |section|
       years_range.each do |year|
         lengths[year] ||= {}
-        section.lines.map do |l|
-          line = l.url_name
-          if section.buildstart && section.buildstart.to_i <= year && (!section.opening || section.opening.to_i > year)
-            lengths[year][line] ||= {}
-            lengths[year][line][:under_construction] ||= 0
-            lengths[year][line][:under_construction] += section.length
-          elsif section.opening && section.opening.to_i <= year && (!section.closure || section.closure.to_i > year)
-            lengths[year][line] ||= {}
-            lengths[year][line][:operative] ||= 0
-            lengths[year][line][:operative] += section.length
-          end
+        if section.buildstart && section.buildstart.to_i <= year && (!section.opening || section.opening.to_i > year)
+          lengths[year][section.id] ||= {
+            lines: section.lines.map(&:url_name)
+          }
+          lengths[year][section.id][:under_construction] = section.length
+        elsif section.opening && section.opening.to_i <= year && (!section.closure || section.closure.to_i > year)
+          lengths[year][section.id] ||= {
+            lines: section.lines.map(&:url_name)
+          }
+          lengths[year][section.id][:operative] = section.length
         end
       end
     end

--- a/api/app/helpers/city_helpers.rb
+++ b/api/app/helpers/city_helpers.rb
@@ -74,9 +74,31 @@ module CityHelpers
     features_collection
   end
 
+  def update_feature_lines(feature, properties)
+    current_lines = feature.lines.map(&:url_name)
+    updated_lines = properties[:lines].map{|l| l[:line_url_name]}
+
+    lines_to_remove = current_lines - updated_lines
+    lines_to_add = updated_lines - current_lines
+
+    unless feature.id
+      feature.save
+    end
+
+    # Remove
+    lines_to_remove.map do |url_name|
+      Line[url_name: url_name].remove_from_feature(feature)
+    end
+
+    # Add
+    lines_to_add.map do |url_name|
+      Line[url_name: url_name].add_to_feature(feature)
+    end
+  end
+
   def update_feature_properties(feature, properties)
-    line_id = Line[url_name: properties[:line_url_name]].id
-    feature.line_id = line_id
+    update_feature_lines(feature, properties)
+
     feature.buildstart = properties[:buildstart]
     feature.opening = properties[:opening]
     feature.closure = properties[:closure]

--- a/api/app/helpers/city_helpers.rb
+++ b/api/app/helpers/city_helpers.rb
@@ -49,8 +49,15 @@ module CityHelpers
     klass.where(city_id: city.id)
   end
 
+  def formatted_lines_features_collection(city, type)
+    features = features_query(city, type).map(&:formatted_feature).flatten
+
+    {type: "FeatureCollection",
+     features: features}
+  end
+
   def lines_features_collection(city, type)
-    features = features_query(city, type).map(&:feature).flatten
+    features = features_query(city, type).map(&:raw_feature)
 
     {type: "FeatureCollection",
      features: features}

--- a/api/app/helpers/city_helpers.rb
+++ b/api/app/helpers/city_helpers.rb
@@ -44,6 +44,11 @@ module CityHelpers
     lengths
   end
 
+  def feature_lines_query(city, type)
+    klass = type == 'sections' ? SectionLine : StationLine
+    klass.where(city_id: city.id)
+  end
+
   def features_query(city, type)
     klass = type == 'sections' ? Section : Station
     klass.where(city_id: city.id)

--- a/api/app/helpers/city_helpers.rb
+++ b/api/app/helpers/city_helpers.rb
@@ -114,14 +114,11 @@ module CityHelpers
   def update_feature_geometry(feature, geometry)
     feature.set_geometry_from_geojson(geometry)
     feature.save
-    # Some logging
-    puts "Update feature geometry log:"
-    puts feature
-    puts "feature class #{feature.class}"
-    #
-    feature.reload
-    feature.set_length if feature.is_a?(Section)
-    feature.save
+
+    if feature.is_a?(Section)
+      feature.set_length
+      feature.save
+    end
   end
 
   def update_create_or_delete_feature(city, user, change)

--- a/api/app/helpers/city_helpers.rb
+++ b/api/app/helpers/city_helpers.rb
@@ -6,7 +6,7 @@ module CityHelpers
       { name: line.name,
         url_name: line.url_name,
         color: line.color,
-        deletable: SectionLine.where(line_id: line.id).count == 0 && Station.where(line_id: line.id).count == 0,
+        deletable: SectionLine.where(line_id: line.id).count == 0 && StationLine.where(line_id: line.id).count == 0,
         system_id: line.system_id}
     }
 

--- a/api/app/helpers/city_helpers.rb
+++ b/api/app/helpers/city_helpers.rb
@@ -50,7 +50,7 @@ module CityHelpers
   end
 
   def lines_features_collection(city, type)
-    features = features_query(city, type).map(&:feature)
+    features = features_query(city, type).map(&:feature).flatten
 
     {type: "FeatureCollection",
      features: features}

--- a/api/app/models/lines.rb
+++ b/api/app/models/lines.rb
@@ -8,8 +8,6 @@ class Line < Sequel::Model(:lines)
 
   many_to_one :city
   many_to_one :system
-  one_to_many :sections
-  one_to_many :stations
 
   def generate_url_name
     self.url_name = "#{self.id}-#{self.name.strip.accentless.gsub(/\s|\//,'-').downcase}"

--- a/api/app/models/lines.rb
+++ b/api/app/models/lines.rb
@@ -12,4 +12,18 @@ class Line < Sequel::Model(:lines)
   def generate_url_name
     self.url_name = "#{self.id}-#{self.name.strip.accentless.gsub(/\s|\//,'-').downcase}"
   end
+
+  def remove_from_feature(feature)
+    klass = feature.is_a?(Section) ? SectionLine : StationLine
+    attr = feature.is_a?(Section) ? :section_id : :station_id
+
+    klass.where(attr => feature.id, :line_id => id).first.delete
+  end
+
+  def add_to_feature(feature)
+    klass = feature.is_a?(Section) ? SectionLine : StationLine
+    attr = feature.is_a?(Section) ? :section_id : :station_id
+
+    klass.create(attr => feature.id, :line_id => id, city_id: city.id)
+  end
 end

--- a/api/app/models/section_line.rb
+++ b/api/app/models/section_line.rb
@@ -1,0 +1,5 @@
+class SectionLine < Sequel::Model
+  plugin :timestamps, :update_on_create => true
+  many_to_one :section
+  many_to_one :line
+end

--- a/api/app/models/sections.rb
+++ b/api/app/models/sections.rb
@@ -31,6 +31,7 @@ class Section < Sequel::Model(:sections)
 
     if line
       h[:properties].merge!(
+        id: "#{id}-#{line.url_name}",
         line: line.name,
         line_url_name: line.url_name,
         system: line.system.name || '',

--- a/api/app/models/sections.rb
+++ b/api/app/models/sections.rb
@@ -56,13 +56,15 @@ class Section < Sequel::Model(:sections)
     end
   end
 
-  def feature
-    feature_hash = super
+  def raw_feature
+    build_feature(feature, line)
+  end
 
+  def formatted_feature
     if other_line_ids
-      multiple_features(feature_hash)
+      multiple_features(feature)
     else
-      build_feature(feature_hash, line)
+      raw_feature
     end
   end
 end

--- a/api/app/models/sections.rb
+++ b/api/app/models/sections.rb
@@ -38,9 +38,9 @@ class Section < Sequel::Model(:sections)
     else
       h[:properties][:lines] = lines.map do |l|
         {
-          line: l.name,
-          line_url_name: l.url_name,
-          system: l.system.name || ''
+          name: l.name,
+          url_name: l.url_name,
+          system_name: l.system.name || ''
         }
       end
     end

--- a/api/app/models/sections.rb
+++ b/api/app/models/sections.rb
@@ -12,21 +12,57 @@ class Section < Sequel::Model(:sections)
 
   FUTURE = 999999
 
-  def feature
-    h = super
-
+  def build_feature(h, line, opts={})
     closure = self.closure || FUTURE
 
     h[:properties].merge!({length: self.length,
-                           line: self.line.name,
-                           line_url_name: self.line.url_name,
-                           system: self.line.system.name || '',
+                           line: line.name,
+                           line_url_name: line.url_name,
+                           system: line.system.name || '',
                            opening: self.opening || FUTURE,
                            buildstart: self.buildstart || self.opening,
                            buildstart_end: self.opening || closure,
                            osm_id: self.osm_id,
                            osm_tags: self.osm_tags,
                            closure: closure })
+
+    h[:properties].merge!(opts)
+
     h
+  end
+
+  def ranges(lines)
+    width = 7
+    ranges = lines/2
+    arr = (-ranges..ranges).to_a
+    if lines.even?
+      arr = arr[0..-2]
+    end
+    arr.map{ |a|
+      f = a * width
+      if lines.even?
+        f = f + width.to_f / 2
+      end
+      f
+    }
+  end
+
+  def multiple_features(feature_hash)
+    lines = other_line_ids.split(',').map{|lid| Line[lid]} + [line]
+    offsets = ranges(lines.count)
+    lines.each_with_index.map do |l, index|
+      hash_clone = Marshal.load(Marshal.dump(feature_hash))
+      build_feature(hash_clone, l, offset: offsets[index])
+    end
+  end
+
+  def feature
+    feature_hash = super
+
+    if other_line_ids
+      multiple_features(feature_hash)
+    else
+      build_feature(feature_hash, line)
+    end
   end
 end

--- a/api/app/models/sections.rb
+++ b/api/app/models/sections.rb
@@ -38,9 +38,9 @@ class Section < Sequel::Model(:sections)
     else
       h[:properties][:lines] = lines.map do |l|
         {
-          name: l.name,
-          url_name: l.url_name,
-          system_name: l.system.name || ''
+          line: l.name,
+          line_url_name: l.url_name,
+          system: l.system.name || ''
         }
       end
     end

--- a/api/app/models/station_line.rb
+++ b/api/app/models/station_line.rb
@@ -1,0 +1,5 @@
+class StationLine < Sequel::Model
+  plugin :timestamps, :update_on_create => true
+  many_to_one :station
+  many_to_one :line
+end

--- a/api/app/models/stations.rb
+++ b/api/app/models/stations.rb
@@ -4,19 +4,34 @@ class Station < Sequel::Model(:stations)
   include StartYear
   include FeatureBackup
 
-  many_to_one :line
+  one_to_many :station_lines
   many_to_one :city
 
   plugin :geometry
+
+  def lines
+    @lines ||= station_lines.map(&:line)
+  end
+
+  def line_url_name
+    lines.count > 1 ? "shared-station" : lines.first.url_name
+  end
+
+  def lines_data
+    lines.map do |l|
+      {name: l.name,
+       url_name: l.url_name,
+       system_name: l.system.name}
+    end
+  end
 
   def feature
     h = super
 
     closure = self.closure || Section::FUTURE
 
-    h[:properties].merge!({line:self.line.name,
-                           line_url_name: self.line.url_name,
-                           system: self.line.system.name || '',
+    h[:properties].merge!({line_url_name: line_url_name,
+                           lines: lines_data,
                            name: self.name,
                            opening: self.opening || Section::FUTURE,
                            buildstart: self.buildstart || self.opening,

--- a/api/app/models/stations.rb
+++ b/api/app/models/stations.rb
@@ -21,7 +21,7 @@ class Station < Sequel::Model(:stations)
     lines.map do |l|
       {line: l.name,
        line_url_name: l.url_name,
-       system: l.system.name}
+       system: l.system.name || ''}
     end
   end
 

--- a/api/app/models/stations.rb
+++ b/api/app/models/stations.rb
@@ -20,7 +20,11 @@ class Station < Sequel::Model(:stations)
   end
 
   def line_url_name
-    shared_station? ? SHARED_STATION_LINE_URL_NAME : lines.first.url_name
+    if shared_station?
+      SHARED_STATION_LINE_URL_NAME
+    elsif lines.first
+      lines.first.url_name
+    end
   end
 
   def lines_data

--- a/api/app/models/stations.rb
+++ b/api/app/models/stations.rb
@@ -26,4 +26,12 @@ class Station < Sequel::Model(:stations)
                            closure: closure })
     h
   end
+
+  def raw_feature
+    feature
+  end
+
+  def formatted_feature
+    feature
+  end
 end

--- a/api/app/models/stations.rb
+++ b/api/app/models/stations.rb
@@ -19,9 +19,9 @@ class Station < Sequel::Model(:stations)
 
   def lines_data
     lines.map do |l|
-      {name: l.name,
-       url_name: l.url_name,
-       system_name: l.system.name}
+      {line: l.name,
+       line_url_name: l.url_name,
+       system: l.system.name}
     end
   end
 

--- a/api/db/migrations/1511017062_adds_other_lines_column_to_sections_table.rb
+++ b/api/db/migrations/1511017062_adds_other_lines_column_to_sections_table.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :sections do
+      add_column :other_line_ids, String, null: true
+    end
+  end
+end

--- a/api/db/migrations/1511017062_adds_other_lines_column_to_sections_table.rb
+++ b/api/db/migrations/1511017062_adds_other_lines_column_to_sections_table.rb
@@ -1,7 +1,0 @@
-Sequel.migration do
-  change do
-    alter_table :sections do
-      add_column :other_line_ids, String, null: true
-    end
-  end
-end

--- a/api/db/migrations/1511028945_creates_section_lines_table.rb
+++ b/api/db/migrations/1511028945_creates_section_lines_table.rb
@@ -1,0 +1,17 @@
+Sequel.migration do
+  change do
+    create_table(:section_lines) do
+      primary_key :id
+      Integer :section_id, null: false, index: true
+      Integer :line_id, null: false
+      DateTime :created_at
+      DateTime :updated_at
+    end
+
+    from(:sections).each do |section|
+      from(:section_lines).insert(section_id: section[:id], line_id: section[:line_id])
+    end
+
+    drop_column :sections, :line_id
+  end
+end

--- a/api/db/migrations/1511031155_adds_city_id_to_section_lines.rb
+++ b/api/db/migrations/1511031155_adds_city_id_to_section_lines.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  change do
+    alter_table :section_lines do
+      add_column :city_id, Integer
+      add_index :city_id
+    end
+
+    from(:section_lines).each do |sl|
+      section = from(:sections)[id: sl[:section_id]]
+      from(:section_lines).where(section_id: section[:id]).update(city_id: section[:city_id])
+    end
+  end
+end

--- a/api/db/migrations/1511032103_create_station_lines_table.rb
+++ b/api/db/migrations/1511032103_create_station_lines_table.rb
@@ -1,0 +1,18 @@
+Sequel.migration do
+  change do
+    create_table(:station_lines) do
+      primary_key :id
+      Integer :station_id, null: false, index: true
+      Integer :line_id, null: false
+      Integer :city_id, null: false, index: true
+      DateTime :created_at
+      DateTime :updated_at
+    end
+
+    from(:stations).each do |station|
+      from(:station_lines).insert(station_id: station[:id], line_id: station[:line_id], city_id: station[:city_id])
+    end
+
+    drop_column :stations, :line_id
+  end
+end

--- a/api/db/migrations/1511100704_removes_line_ids_from_backup_tables.rb
+++ b/api/db/migrations/1511100704_removes_line_ids_from_backup_tables.rb
@@ -1,0 +1,6 @@
+Sequel.migration do
+  change do
+    drop_column :section_backups, :line_id
+    drop_column :station_backups, :line_id
+  end
+end

--- a/api/test/unit/helpers/cache_helpers.rb
+++ b/api/test/unit/helpers/cache_helpers.rb
@@ -8,7 +8,7 @@ describe CacheHelpers do
   describe "last_modified_city_date" do
     it "should return the last section updated_at" do
       section1 = Timecop.freeze(Date.today - 4) do
-        Section.create(city_id: 33, line_id: 222)
+        Section.create(city_id: 33)
       end
 
       system1 = Timecop.freeze(Date.today - 3) do
@@ -19,14 +19,14 @@ describe CacheHelpers do
         System.create(city_id: 33)
       end
 
-      section2  = Section.create(city_id: 33, line_id: 222)
+      section2  = Section.create(city_id: 33)
 
       assert_equal section2.updated_at, last_modified_city_date
     end
 
     it "should return the last system updated_at" do
       section1 = Timecop.freeze(Date.today - 4) do
-        Section.create(city_id: 33, line_id: 222)
+        Section.create(city_id: 33)
       end
 
       system1 = Timecop.freeze(Date.today - 3) do
@@ -34,7 +34,7 @@ describe CacheHelpers do
       end
 
       section2 = Timecop.freeze(Date.today - 2) do
-        Section.create(city_id: 33, line_id: 222)
+        Section.create(city_id: 33)
       end
 
       system2 = System.create(city_id: 33)
@@ -44,7 +44,7 @@ describe CacheHelpers do
 
     it "should return the last DeletedFeature created_at" do
       section1 = Timecop.freeze(Date.today - 4) do
-        Section.create(city_id: 33, line_id: 222)
+        Section.create(city_id: 33)
       end
 
       system1 = Timecop.freeze(Date.today - 3) do
@@ -52,7 +52,7 @@ describe CacheHelpers do
       end
 
       section2 = Timecop.freeze(Date.today - 2) do
-        Section.create(city_id: 33, line_id: 222)
+        Section.create(city_id: 33)
       end
 
       deleted_feature = DeletedFeature.create(feature_class: 'Section', city_id: 33)
@@ -62,7 +62,7 @@ describe CacheHelpers do
 
     it "should return the updated_city" do
       section1 = Timecop.freeze(Date.today - 4) do
-        Section.create(city_id: 33, line_id: 222)
+        Section.create(city_id: 33)
       end
 
       system1 = Timecop.freeze(Date.today - 3) do
@@ -70,7 +70,7 @@ describe CacheHelpers do
       end
 
       section2 = Timecop.freeze(Date.today - 2) do
-        Section.create(city_id: 33, line_id: 222)
+        Section.create(city_id: 33)
       end
 
       city = City.create(name: 'Fake City', system_name: '', country: 'Fake Country', url_name: 'fake-city')
@@ -82,10 +82,7 @@ describe CacheHelpers do
   describe "last_modified_source_feature" do
     before do
       @city = City.create(name: 'Testonia', system_name: '', url_name: 'testonia')
-      @line = Line.create(name: 'Line 1', city_id: @city.id)
-
       @city2 = City.create(name: 'Testonia2', system_name: '', url_name: 'testonia2')
-      @line2 = Line.create(name: 'Line 1', city_id: @city2.id)
     end
 
     describe "sections" do
@@ -95,32 +92,32 @@ describe CacheHelpers do
         end
 
         section1 = Timecop.freeze(Date.today - 2) do
-          Section.create(line_id: @line.id, city_id: @city.id)
+          Section.create(city_id: @city.id)
         end
 
         section2 = Timecop.freeze(Date.today - 1 ) do
-          Section.create(line_id: @line.id, city_id: @city.id)
+          Section.create(city_id: @city.id)
         end
 
-        section_of_another_city = Section.create(line_id: @line2.id, city_id: @city2.id)
+        section_of_another_city = Section.create(city_id: @city2.id)
 
         assert_equal section2.updated_at, last_modified_source_feature(@city, 'sections')
       end
 
       it "should return the last deleted_feature created_at" do
         section1 = Timecop.freeze(Date.today - 3) do
-          Section.create(line_id: @line.id, city_id: @city.id)
+          Section.create(city_id: @city.id)
         end
 
         section2 = Timecop.freeze(Date.today - 2) do
-          Section.create(line_id: @line.id, city_id: @city.id)
+          Section.create(city_id: @city.id)
         end
 
         deleted_feature = Timecop.freeze(Date.today - 1) do
           DeletedFeature.create(city_id: @city.id, feature_class: 'Section')
         end
 
-        section_of_another_city = Section.create(line_id: @line2.id, city_id: @city2.id)
+        section_of_another_city = Section.create(city_id: @city2.id)
 
         assert_equal deleted_feature.created_at, last_modified_source_feature(@city, 'sections')
       end
@@ -133,32 +130,32 @@ describe CacheHelpers do
         end
 
         station1 = Timecop.freeze(Date.today - 2) do
-          Station.create(line_id: @line.id, city_id: @city.id)
+          Station.create(city_id: @city.id)
         end
 
         station2 = Timecop.freeze(Date.today - 1 ) do
-          Station.create(line_id: @line.id, city_id: @city.id)
+          Station.create(city_id: @city.id)
         end
 
-        station_of_another_city = Station.create(line_id: @line2.id, city_id: @city2.id)
+        station_of_another_city = Station.create(city_id: @city2.id)
 
         assert_equal station2.updated_at, last_modified_source_feature(@city, 'stations')
       end
 
       it "should return the last deleted_feature created_at" do
         station1 = Timecop.freeze(Date.today - 3) do
-          Station.create(line_id: @line.id, city_id: @city.id)
+          Station.create(city_id: @city.id)
         end
 
         station2 = Timecop.freeze(Date.today - 2) do
-          Station.create(line_id: @line.id, city_id: @city.id)
+          Station.create(city_id: @city.id)
         end
 
         deleted_feature = Timecop.freeze(Date.today - 1) do
           DeletedFeature.create(city_id: @city.id, feature_class: 'Station')
         end
 
-        station_of_another_city = Station.create(line_id: @line2.id, city_id: @city2.id)
+        station_of_another_city = Station.create(city_id: @city2.id)
 
         assert_equal deleted_feature.created_at, last_modified_source_feature(@city, 'stations')
       end

--- a/api/test/unit/helpers/cache_helpers.rb
+++ b/api/test/unit/helpers/cache_helpers.rb
@@ -104,6 +104,28 @@ describe CacheHelpers do
         assert_equal section2.updated_at, last_modified_source_feature(@city, 'sections')
       end
 
+      it "should return the last modified section_line updated_at" do
+        deleted_feature = Timecop.freeze(Date.today - 3) do
+          DeletedFeature.create(city_id: @city.id, feature_class: 'Section')
+        end
+
+        section1 = Timecop.freeze(Date.today - 2) do
+          Section.create(city_id: @city.id)
+        end
+
+        section_line1 = Timecop.freeze(Date.today - 1 ) do
+          SectionLine.create(section_id: 99, line_id: 99, city_id: @city.id)
+        end
+
+        section_line2 = Timecop.freeze(Date.today) do
+          SectionLine.create(section_id: 99, line_id: 99, city_id: @city.id)
+        end
+
+        section_of_another_city = Section.create(city_id: @city2.id)
+
+        assert_equal section_line2.updated_at, last_modified_source_feature(@city, 'sections')
+      end
+
       it "should return the last deleted_feature created_at" do
         section1 = Timecop.freeze(Date.today - 3) do
           Section.create(city_id: @city.id)
@@ -140,6 +162,28 @@ describe CacheHelpers do
         station_of_another_city = Station.create(city_id: @city2.id)
 
         assert_equal station2.updated_at, last_modified_source_feature(@city, 'stations')
+      end
+
+      it "should return the last modified section_line updated_at" do
+        deleted_feature = Timecop.freeze(Date.today - 3) do
+          DeletedFeature.create(city_id: @city.id, feature_class: 'Station')
+        end
+
+        station1 = Timecop.freeze(Date.today - 2) do
+          Station.create(city_id: @city.id)
+        end
+
+        station_line1 = Timecop.freeze(Date.today - 1 ) do
+          StationLine.create(station_id: 99, line_id: 99, city_id: @city.id)
+        end
+
+        station_line2 = Timecop.freeze(Date.today) do
+          StationLine.create(station_id: 99, line_id: 99, city_id: @city.id)
+        end
+
+        station_of_another_city = Station.create(city_id: @city2.id)
+
+        assert_equal station_line2.updated_at, last_modified_source_feature(@city, 'stations')
       end
 
       it "should return the last deleted_feature created_at" do

--- a/api/test/unit/helpers/city_helpers.rb
+++ b/api/test/unit/helpers/city_helpers.rb
@@ -11,8 +11,11 @@ describe CityHelpers do
     end
 
     it "should return the right length by line by year" do
-      Section.create(city_id: @city.id, line_id: @lineA.id, length:20, buildstart: 1920, opening: 1925, closure: 1930)
-      Section.create(city_id: @city.id, line_id: @lineB.id, length:10, buildstart: 1920, opening: 1925)
+      s1 = Section.create(city_id: @city.id, length:20, buildstart: 1920, opening: 1925, closure: 1930)
+      s2 = Section.create(city_id: @city.id, length:10, buildstart: 1920, opening: 1925)
+
+      SectionLine.create(section_id: s1.id, line_id: @lineA.id, city_id: @city.id)
+      SectionLine.create(section_id: s2.id, line_id: @lineB.id, city_id: @city.id)
 
       result = lines_length_by_year(@city)
 
@@ -45,15 +48,15 @@ describe CityHelpers do
       city1 = City.create(name: 'City 1', system_name: '', url_name: 'city-1', start_year: 2017)
       city2 = City.create(name: 'City 2', system_name: '', url_name: 'city-2', start_year: 2017)
 
-      Section.create(city_id: city1.id, line_id: 33, length: 5000, buildstart: 2010)
-      Section.create(city_id: city1.id, line_id: 33, length: 10000, opening: 2010)
-      Section.create(city_id: city1.id, line_id: 33, length: 15000, opening: 1995)
-      Section.create(city_id: city1.id, line_id: 33, length: 20000, opening: 1990, closure: 1993)
+      Section.create(city_id: city1.id, length: 5000, buildstart: 2010)
+      Section.create(city_id: city1.id, length: 10000, opening: 2010)
+      Section.create(city_id: city1.id, length: 15000, opening: 1995)
+      Section.create(city_id: city1.id, length: 20000, opening: 1990, closure: 1993)
 
-      Section.create(city_id: city2.id, line_id: 33, length: 25000, buildstart: 2010)
-      Section.create(city_id: city2.id, line_id: 33, length: 30000, opening: 2010)
-      Section.create(city_id: city2.id, line_id: 33, length: 35000, opening: 1995)
-      Section.create(city_id: city2.id, line_id: 33, length: 40000, opening: 1990, closure: 1993)
+      Section.create(city_id: city2.id, length: 25000, buildstart: 2010)
+      Section.create(city_id: city2.id, length: 30000, opening: 2010)
+      Section.create(city_id: city2.id, length: 35000, opening: 1995)
+      Section.create(city_id: city2.id, length: 40000, opening: 1990, closure: 1993)
 
       result = lengths
 

--- a/api/test/unit/helpers/city_helpers.rb
+++ b/api/test/unit/helpers/city_helpers.rb
@@ -13,31 +13,55 @@ describe CityHelpers do
     it "should return the right length by line by year" do
       s1 = Section.create(city_id: @city.id, length:20, buildstart: 1920, opening: 1925, closure: 1930)
       s2 = Section.create(city_id: @city.id, length:10, buildstart: 1920, opening: 1925)
+      s3 = Section.create(city_id: @city.id, length:5, buildstart: 1920, opening: 1925)
 
       SectionLine.create(section_id: s1.id, line_id: @lineA.id, city_id: @city.id)
       SectionLine.create(section_id: s2.id, line_id: @lineB.id, city_id: @city.id)
+
+      SectionLine.create(section_id: s3.id, line_id: @lineA.id, city_id: @city.id)
+      SectionLine.create(section_id: s3.id, line_id: @lineB.id, city_id: @city.id)
 
       result = lines_length_by_year(@city)
 
       (1920..2000).each do |year|
         if (1920..1924).include?(year)
-          refute result[year]['a'][:operative]
-          refute result[year]['b'][:operative]
-          assert_equal 20, result[year]['a'][:under_construction]
-          assert_equal 10, result[year]['b'][:under_construction]
+          assert_equal %w(a), result[year][s1.id][:lines]
+          assert_equal %w(b), result[year][s2.id][:lines]
+          assert_equal %w(a b), result[year][s3.id][:lines]
+
+          refute result[year][s1.id][:operative]
+          refute result[year][s2.id][:operative]
+          refute result[year][s3.id][:operative]
+
+          assert_equal 20, result[year][s1.id][:under_construction]
+          assert_equal 10, result[year][s2.id][:under_construction]
+          assert_equal 5, result[year][s3.id][:under_construction]
         end
 
         if (1925..1929).include?(year)
-          assert_equal 20, result[year]['a'][:operative]
-          assert_equal 10, result[year]['b'][:operative]
-          refute result[year]['a'][:under_construction]
-          refute result[year]['b'][:under_construction]
+          assert_equal %w(a), result[year][s1.id][:lines]
+          assert_equal %w(b), result[year][s2.id][:lines]
+          assert_equal %w(a b), result[year][s3.id][:lines]
+
+          assert_equal 20, result[year][s1.id][:operative]
+          assert_equal 10, result[year][s2.id][:operative]
+          assert_equal 5, result[year][s3.id][:operative]
+
+          refute result[year][s1.id][:under_construction]
+          refute result[year][s2.id][:under_construction]
+          refute result[year][s3.id][:under_construction]
         end
 
         if year >= 1930
-          refute result[year]['a']
-          assert_equal 10, result[year]['b'][:operative]
-          refute result[year]['b'][:under_construction]
+          refute result[year][s1.id]
+          assert_equal %w(b), result[year][s2.id][:lines]
+          assert_equal %w(a b), result[year][s3.id][:lines]
+
+          assert_equal 10, result[year][s2.id][:operative]
+          assert_equal 5, result[year][s3.id][:operative]
+
+          refute result[year][s2.id][:under_construction]
+          refute result[year][s3.id][:under_construction]
         end
       end
     end

--- a/api/test/unit/helpers/osm_helpers.rb
+++ b/api/test/unit/helpers/osm_helpers.rb
@@ -205,11 +205,10 @@ describe OSMHelpers do
   describe "filter_out_existing_features" do
     before do
       @city = City.create(name: 'Test city', system_name: '', url_name:'test-city')
-      @line = Line.create(name: 'Test Line 1', city_id: @city.id)
     end
 
     it "should filter out any existing station" do
-      Station.create(line_id: @line.id, osm_id: 81551275, city_id: @city.id)
+      Station.create(osm_id: 81551275, city_id: @city.id)
 
       response = {
         elements: [
@@ -244,7 +243,7 @@ describe OSMHelpers do
     end
 
     it "should filter out any existing section" do
-      Section.create(line_id: @line.id, osm_id: 26192812, city_id: @city.id)
+      Section.create(osm_id: 26192812, city_id: @city.id)
 
       response = {
         elements: [

--- a/api/test/unit/helpers/user_helpers.rb
+++ b/api/test/unit/helpers/user_helpers.rb
@@ -13,7 +13,7 @@ describe UserHelpers do
       @city3 = City.create(name: 'Berazategui', url_name: 'berazategui', system_name:'', coords: Sequel.lit("ST_GeomFromText('POINT(-71.064544 42.28787)',4326)"))
       @city4 = City.create(name: 'Chivilcoy', url_name: 'chivilcoy', system_name:'', coords: Sequel.lit("ST_GeomFromText('POINT(-71.064544 42.28787)',4326)"))
 
-      section = Section.create(city_id: @city.id, line_id: 666, length: 3450, geometry: Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)"))
+      section = Section.create(city_id: @city.id, length: 3450, geometry: Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)"))
 
       # Created features in city 1
       CreatedFeature.create(feature_class: 'Section', feature_id: section.id, user_id: @user_id, city_id: @city.id)
@@ -83,9 +83,9 @@ describe UserHelpers do
       @pepe = User.create(name: "Pepe Martínez", email: 'pepe@test.com')
       @jorge = User.create(name: "Jorge Rodríguez", email: 'jorge@test.com')
 
-      section = Section.create(city_id: 22, line_id: 666, length: 3450, geometry: Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)"))
-      section2 = Section.create(city_id: 22, line_id: 666, length: 4450, geometry: Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)"))
-      section3 = Section.create(city_id: 22, line_id: 666, length: 5450, geometry: Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)"))
+      section = Section.create(city_id: 22, length: 3450, geometry: Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)"))
+      section2 = Section.create(city_id: 22, length: 4450, geometry: Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)"))
+      section3 = Section.create(city_id: 22, length: 5450, geometry: Sequel.lit("ST_GeomFromText('LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)',4326)"))
 
       CreatedFeature.create(user_id: @juan.id, feature_class: 'Section', feature_id: section.id, created_at: Date.today)
       CreatedFeature.create(user_id: @pepe.id, feature_class: 'Section', feature_id: section2.id, created_at: Date.today)

--- a/api/test/unit/models/lines.rb
+++ b/api/test/unit/models/lines.rb
@@ -45,4 +45,30 @@ describe Line do
     assert_equal @line.color, backup.color
     assert_equal @line.system_id, backup.system_id
   end
+
+  describe "add/remove to/from features" do
+    before do
+      @feature = Section.create(city_id: @city.id)
+    end
+
+    it "should be added to the feature" do
+      assert 0, @feature.lines.count
+
+      @line.add_to_feature(@feature)
+
+      assert 1, @feature.lines.count
+
+      assert @line, @feature.lines.first
+    end
+
+    it "should be removed from the feature" do
+      @line.add_to_feature(@feature)
+
+      assert 1, @feature.lines.count
+
+      @line.remove_from_feature(@feature)
+
+      assert 0, @feature.lines.count
+    end
+  end
 end

--- a/api/test/unit/models/modified_features_models.rb
+++ b/api/test/unit/models/modified_features_models.rb
@@ -13,9 +13,7 @@ describe "modified features models" do
 
     @user = User.create(name: 'Test User', email: 'test@user.com')
 
-    @line = Line.create(city_id: @city.id, name: 'L1')
-
-    @feature = Section.create(line_id: @line.id, city_id: @city.id)
+    @feature = Section.create(city_id: @city.id)
   end
 
   it "should should try to create a models instance" do

--- a/api/test/unit/models/stations.rb
+++ b/api/test/unit/models/stations.rb
@@ -161,14 +161,17 @@ describe Station do
       assert_equal '', @station.reload.feature[:properties][:lines].first[:system]
     end
 
-    it "should return the 'shared station' url_name if it has more than 1 line" do
+    it "should return the 'shared station' url_name, and the extra url_nam attrs, if it has more than 1 line" do
       second_line = Line.create(name:'Other line', city_id: @city.id, url_name:'other-line-url-name', system_id: @system.id)
 
       StationLine.create(line_id: second_line.id, station_id: @station.id, city_id: @city.id)
 
+      feature_props = @station.feature[:properties]
+
       assert_equal 2, @station.lines.count
-      assert_equal 'shared-station', @station.line_url_name
-      #TODO
+      assert_equal Station::SHARED_STATION_LINE_URL_NAME, feature_props[:line_url_name]
+      assert_equal 'a-url-name', feature_props[:line_url_name_1]
+      assert_equal 'other-line-url-name', feature_props[:line_url_name_2]
     end
   end
 end

--- a/api/test/unit/models/stations.rb
+++ b/api/test/unit/models/stations.rb
@@ -13,11 +13,13 @@ describe Station do
 
     @system = System.create(city_id: @city.id, name: 'A system')
 
-    @line = Line.create(city_id: @city.id, system_id: @system.id, name: 'Test line')
+    @line = Line.create(city_id: @city.id, system_id: @system.id, name: 'Test line', url_name: 'a-url-name')
 
-    @station = Station.new(line_id: @line.id, buildstart: 1980, opening:1985, closure: 1999, name: 'Some station', osm_id: 456, osm_tags: 'tags', city_id: @city.id)
+    @station = Station.new(buildstart: 1980, opening:1985, closure: 1999, name: 'Some station', osm_id: 456, osm_tags: 'tags', city_id: @city.id)
     @station.geometry = Sequel.lit("ST_GeomFromText('POINT(-71.064544 42.28787)',4326)")
     @station.save
+
+    StationLine.create(station_id: @station.id, line_id: @line.id, city_id: @city.id)
 
     @city.reload
   end
@@ -31,7 +33,6 @@ describe Station do
     backup = StationBackup.first
 
     assert_equal @station.id, backup.original_id
-    assert_equal @station.line_id, backup.line_id
     assert_equal @station.geometry, backup.geometry
     assert_equal @station.buildstart, backup.buildstart
     assert_equal @station.opening, backup.opening
@@ -58,18 +59,33 @@ describe Station do
     assert_equal @city, @station.city
   end
 
+  it "should return the lines" do
+    assert_equal [@line], @station.lines
+  end
+
   describe "feature" do
+    it "should be equal to raw_feature and formatted_feature" do
+      feature = @station.feature
+      assert_equal feature, @station.raw_feature
+      assert_equal feature, @station.formatted_feature
+    end
+
     it "should return the right feature" do
       feature = @station.feature
 
       assert_equal 'Feature', feature[:type]
       assert feature[:geometry]
 
+      expected_lines = [{
+        line: @line.name,
+        line_url_name: @line.url_name,
+        system: @system.name
+      }]
+
       expected_properties = {id: @station.id,
                              klass: "Station",
-                             line: @station.line.name,
-                             line_url_name: @station.line.url_name,
-                             system: @system.name,
+                             lines: expected_lines,
+                             line_url_name: @station.lines.first.url_name,
                              name: @station.name,
                              opening: @station.opening,
                              buildstart: @station.buildstart,
@@ -88,11 +104,16 @@ describe Station do
 
       feature = @station.feature
 
+      expected_lines = [{
+        line: @line.name,
+        line_url_name: @line.url_name,
+        system: @system.name
+      }]
+
       expected_properties = {id: @station.id,
                              klass: "Station",
-                             line: @station.line.name,
-                             line_url_name: @station.line.url_name,
-                             system: @system.name,
+                             lines: expected_lines,
+                             line_url_name: @station.lines.first.url_name,
                              name: @station.name,
                              opening: Section::FUTURE,
                              buildstart: @station.buildstart,
@@ -110,11 +131,16 @@ describe Station do
 
       feature = @station.feature
 
+      expected_lines = [{
+        line: @line.name,
+        line_url_name: @line.url_name,
+        system: @system.name
+      }]
+
       expected_properties = {id: @station.id,
                              klass: "Station",
-                             line: @station.line.name,
-                             line_url_name: @station.line.url_name,
-                             system: @system.name,
+                             lines: expected_lines,
+                             line_url_name: @station.lines.first.url_name,
                              name: @station.name,
                              opening: @station.opening,
                              buildstart: @station.opening,
@@ -132,7 +158,17 @@ describe Station do
       @line.system_id = system.id
       @line.save
 
-      assert_equal '', @station.reload.feature[:properties][:system]
+      assert_equal '', @station.reload.feature[:properties][:lines].first[:system]
+    end
+
+    it "should return the 'shared station' url_name if it has more than 1 line" do
+      second_line = Line.create(name:'Other line', city_id: @city.id, url_name:'other-line-url-name', system_id: @system.id)
+
+      StationLine.create(line_id: second_line.id, station_id: @station.id, city_id: @city.id)
+
+      assert_equal 2, @station.lines.count
+      assert_equal 'shared-station', @station.line_url_name
+      #TODO
     end
   end
 end

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -31,14 +31,20 @@
 }
 
 .popup-feature-info {
-    margin-top:5px;
+  display: block;
+  margin-top:5px;
+}
+
+.popup-feature-adjacent {
+  border-top: 1px dashed #c0c0c0;
+  padding-top: 7px;
+  margin-top: 5px;
 }
 
 .station-popup {
   display: block;
-  margin-bottom:7px;
+  margin-bottom:5px;
   font-size:1.15em;
-  border-bottom: 1px dotted #888;
 }
 
 .section-popup {

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -158,6 +158,22 @@
   left:3px;
 }
 
+.editor-features-lines-item {
+  padding: 2px 0;
+}
+
+.editor-features-lines-item .fa-close {
+  position: absolute;
+  right: 30px;
+  margin-top:3px;
+  color: #888;
+}
+
+.editor-features-lines-item .fa-close:hover {
+  color: #000;
+  cursor: pointer;
+}
+
 .color-picker-container {
   position:absolute;
   z-index:100000;

--- a/client/assets/css/style.css
+++ b/client/assets/css/style.css
@@ -35,7 +35,10 @@
 }
 
 .station-popup {
-  text-decoration: underline;
+  display: block;
+  margin-bottom:7px;
+  font-size:1.15em;
+  border-bottom: 1px dotted #888;
 }
 
 .section-popup {

--- a/client/locales/en.js
+++ b/client/locales/en.js
@@ -59,12 +59,12 @@ export default {
     feature_viewer: {
       selected_feature: 'Selected feature',
       no_feature_selected: 'No feature selected',
+      add_line: 'Add line',
       fields: {
         klasses_id: {
           section: 'Track Id:%(id)s',
           station: 'Station Id:%(id)s'
         },
-        line: 'Line',
         name: 'Name',
         opening: 'Opening',
         buildstart: 'Beginning of construction',

--- a/client/locales/es.js
+++ b/client/locales/es.js
@@ -59,12 +59,12 @@ export default {
     feature_viewer: {
       selected_feature: 'Elemento seleccionado',
       no_feature_selected: 'Ningún elemento seleccionado',
+      add_line: 'Agregar línea',
       fields: {
         klasses_id: {
           section_id: 'Tramo Id:%(id)s',
           station_id: 'Estación Id:%(id)s'
         },
-        line: 'Línea',
         name: 'Nombre',
         opening: 'Inauguración',
         buildstart: 'Comienzo de construcción',

--- a/client/src/components/city.js
+++ b/client/src/components/city.js
@@ -186,10 +186,11 @@ class City extends PureComponent {
               onClose={this.bindedOnPopupClose}>
               <div>
               {
-                this.state.clickedFeatures.features.map((f) =>
+                this.state.clickedFeatures.features.map((f,i) =>
                     <FeaturePopupContent
                       key={`${f.properties.klass}-${f.properties.id}-${f.properties.line_url_name}`}
-                      feature={f} />)
+                      feature={f}
+                      index={i} />)
               }
               </div>
               </Popup>) }

--- a/client/src/components/city.js
+++ b/client/src/components/city.js
@@ -5,6 +5,7 @@ import {PanelHeader, PanelBody} from './panel';
 import {Map, Source, Layer, Popup, Draw} from './map';
 
 import Translate from 'react-translate-component';
+import FeaturePopupContent from './city/feature-popup-content';
 
 import MainStore from '../stores/main-store';
 import CityStore from '../stores/city-store';
@@ -97,10 +98,6 @@ class City extends PureComponent {
     }
   }
 
-  validFeatureValue(value) {
-    return (value !== null && value !== 999999)
-  }
-
   onMouseMove(point, features) {
     CityViewStore.hover(this.urlName, features);
   }
@@ -189,26 +186,10 @@ class City extends PureComponent {
               onClose={this.bindedOnPopupClose}>
               <div>
               {
-                this.state.clickedFeatures.features.map((feature) => {
-                  const fProps = feature.properties;
-                  const lineStyle = {color: fProps.lineLabelColor, backgroundColor: fProps.lineColor, marginLeft: (fProps.system ? 5 : 0), boxShadow: (fProps.lineLabelColor === '#000' ? '0 0 1px rgba(0,0,0,0.5)' : null)};
-                  return (
-                    <div key={`${fProps.klass}_${fProps.id}`} className="c-text popup-feature-info">
-                      <ul className="c-list c-list--unstyled">
-                        <li className="c-list__item">
-                          <strong>{fProps.system}</strong><span className="c-text--highlight line-label" style={lineStyle}>{fProps.line}</span>
-                        </li>
-                        <li className="c-list__item">
-                          {fProps.klass === 'Station' ? <Translate className="station-popup" content="city.popup.station" with={{name: fProps.name}} /> : <Translate className="section-popup" content="city.popup.track" />}
-                        </li>
-                        { fProps.buildstart ? <li className="c-list__item"><Translate content="city.popup.buildstart" with={{year: fProps.buildstart}} /></li> : ''}
-                        { this.validFeatureValue(fProps.opening) ? <li className="c-list__item"><Translate content="city.popup.opening" with={{year: fProps.opening}} /></li> : ''}
-                        { this.validFeatureValue(fProps.closure) ? <li className="c-list__item"><Translate content="city.popup.closure" with={{year: fProps.closure}} /></li> : ''}
-                        { fProps.length ? <li className="c-list__item"><Translate content="city.popup.length" with={{km: (parseFloat(fProps.length)/1000).toFixed(2)}} /></li> : ''}
-                      </ul>
-                    </div>
-                  )
-                })
+                this.state.clickedFeatures.features.map((f) =>
+                    <FeaturePopupContent
+                      key={`${f.properties.klass}-${f.properties.id}-${f.properties.line_url_name}`}
+                      feature={f} />)
               }
               </div>
               </Popup>) }

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -1,0 +1,72 @@
+import React, {Component} from 'react';
+import Translate from 'react-translate-component';
+
+class FeaturePopupContent extends Component {
+  fProps() {
+    return this.props.feature.properties;
+  }
+
+  lineStyle(p) {
+    return {color: p.lineLabelColor, backgroundColor: p.lineColor, marginLeft: 0, marginRight: 5, boxShadow: (p.lineLabelColor === '#000' ? '0 0 1px rgba(0,0,0,0.5)' : null)};
+  }
+
+  validFeatureValue(value) {
+    return (value !== null && value !== 999999)
+  }
+
+  groupedSystems(linesInfo) {
+    let systems = {};
+
+    linesInfo.map((l) => {
+      if (!systems[l.system]) {
+        systems[l.system] = {name: l.system, lines: []}
+      };
+
+      systems[l.system].lines.push(l)
+    });
+
+    return systems;
+  }
+
+  render() {
+    const fProps = this.fProps();
+
+    return (
+        <div className="c-text popup-feature-info">
+        <ul className="c-list c-list--unstyled">
+        {fProps.klass === 'Station' ?
+          <div>
+            <li className="c-list__item">
+            <Translate className="station-popup" content="city.popup.station" with={{name: fProps.name}} />
+            </li>
+            {Object.entries(this.groupedSystems(fProps.lines)).map((e) => {
+                const s = e[1];
+                return <li className="c-list__item">
+                  {s.lines.map((l) => <span className="c-text--highlight line-label" style={this.lineStyle(l)}>{l.line}</span>)}
+                  <strong>{s.name}</strong>
+                </li>
+              }
+            )}
+            </div>
+            :
+            <div>
+          <li className="c-list__item">
+            <span className="c-text--highlight line-label" style={this.lineStyle(fProps)}>{fProps.line}</span>
+            <strong>{fProps.system}</strong>
+          </li>
+          <li className="c-list__item">
+            <Translate className="section-popup" content="city.popup.track" />
+          </li>
+          </div>
+        }
+        { fProps.buildstart ? <li className="c-list__item"><Translate content="city.popup.buildstart" with={{year: fProps.buildstart}} /></li> : ''}
+        { this.validFeatureValue(fProps.opening) ? <li className="c-list__item"><Translate content="city.popup.opening" with={{year: fProps.opening}} /></li> : ''}
+        { this.validFeatureValue(fProps.closure) ? <li className="c-list__item"><Translate content="city.popup.closure" with={{year: fProps.closure}} /></li> : ''}
+        { fProps.length ? <li className="c-list__item"><Translate content="city.popup.length" with={{km: (parseFloat(fProps.length)/1000).toFixed(2)}} /></li> : ''}
+        </ul>
+        </div>
+        )
+  }
+}
+
+export default FeaturePopupContent

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -39,10 +39,10 @@ class FeaturePopupContent extends Component {
             <li className="c-list__item">
             <Translate className="station-popup" content="city.popup.station" with={{name: fProps.name}} />
             </li>
-            {Object.entries(this.groupedSystems(fProps.lines)).map((e) => {
+            {Object.entries(this.groupedSystems(fProps.lines)).map((e, index) => {
                 const s = e[1];
-                return <li className="c-list__item">
-                  {s.lines.map((l) => <span className="c-text--highlight line-label" style={this.lineStyle(l)}>{l.line}</span>)}
+                return <li key={index} className="c-list__item">
+                  {s.lines.map((l, index2) => <span key={`l-${index2}`} className="c-text--highlight line-label" style={this.lineStyle(l)}>{l.line}</span>)}
                   <strong>{s.name}</strong>
                 </li>
               }

--- a/client/src/components/city/feature-popup-content.js
+++ b/client/src/components/city/feature-popup-content.js
@@ -33,37 +33,37 @@ class FeaturePopupContent extends Component {
 
     return (
         <div className="c-text popup-feature-info">
-        <ul className="c-list c-list--unstyled">
-        {fProps.klass === 'Station' ?
-          <div>
-            <li className="c-list__item">
-            <Translate className="station-popup" content="city.popup.station" with={{name: fProps.name}} />
-            </li>
-            {Object.entries(this.groupedSystems(fProps.lines)).map((e, index) => {
-                const s = e[1];
-                return <li key={index} className="c-list__item">
-                  {s.lines.map((l, index2) => <span key={`l-${index2}`} className="c-text--highlight line-label" style={this.lineStyle(l)}>{l.line}</span>)}
-                  <strong>{s.name}</strong>
-                </li>
-              }
-            )}
-            </div>
-            :
+          <ul className={`c-list c-list--unstyled ${this.props.index > 0 ? 'popup-feature-adjacent' : ''}`}>
+          {fProps.klass === 'Station' ?
             <div>
-          <li className="c-list__item">
-            <span className="c-text--highlight line-label" style={this.lineStyle(fProps)}>{fProps.line}</span>
-            <strong>{fProps.system}</strong>
-          </li>
-          <li className="c-list__item">
-            <Translate className="section-popup" content="city.popup.track" />
-          </li>
-          </div>
-        }
-        { fProps.buildstart ? <li className="c-list__item"><Translate content="city.popup.buildstart" with={{year: fProps.buildstart}} /></li> : ''}
-        { this.validFeatureValue(fProps.opening) ? <li className="c-list__item"><Translate content="city.popup.opening" with={{year: fProps.opening}} /></li> : ''}
-        { this.validFeatureValue(fProps.closure) ? <li className="c-list__item"><Translate content="city.popup.closure" with={{year: fProps.closure}} /></li> : ''}
-        { fProps.length ? <li className="c-list__item"><Translate content="city.popup.length" with={{km: (parseFloat(fProps.length)/1000).toFixed(2)}} /></li> : ''}
-        </ul>
+              <li className="c-list__item">
+                <Translate className="station-popup" content="city.popup.station" with={{name: fProps.name}} />
+              </li>
+              {Object.entries(this.groupedSystems(fProps.lines)).map((e, index) => {
+                  const s = e[1];
+                  return <li key={index} className="c-list__item">
+                    {s.lines.map((l, index2) => <span key={`l-${index2}`} className="c-text--highlight line-label" style={this.lineStyle(l)}>{l.line}</span>)}
+                    <strong>{s.name}</strong>
+                  </li>
+                }
+              )}
+            </div>
+              :
+            <div>
+              <li className="c-list__item">
+                <span className="c-text--highlight line-label" style={this.lineStyle(fProps)}>{fProps.line}</span>
+                <strong>{fProps.system}</strong>
+              </li>
+              <li className="c-list__item">
+                <Translate className="section-popup" content="city.popup.track" />
+              </li>
+            </div>
+          }
+          { fProps.buildstart ? <li className="c-list__item"><Translate content="city.popup.buildstart" with={{year: fProps.buildstart}} /></li> : ''}
+          { this.validFeatureValue(fProps.opening) ? <li className="c-list__item"><Translate content="city.popup.opening" with={{year: fProps.opening}} /></li> : ''}
+          { this.validFeatureValue(fProps.closure) ? <li className="c-list__item"><Translate content="city.popup.closure" with={{year: fProps.closure}} /></li> : ''}
+          { fProps.length ? <li className="c-list__item"><Translate content="city.popup.length" with={{km: (parseFloat(fProps.length)/1000).toFixed(2)}} /></li> : ''}
+          </ul>
         </div>
         )
   }

--- a/client/src/components/editor.js
+++ b/client/src/components/editor.js
@@ -89,7 +89,7 @@ class Editor extends PureComponent {
     EditorStore.changeSelection(this.urlName, features);
   }
 
-  onFeaturePropsChange(feature, modifiedKey, newValue) {
+  onFeaturePropsChange(feature) {
     EditorStore.setFeaturePropsChange(this.urlName, feature);
   }
 

--- a/client/src/components/editor/feature-viewer.js
+++ b/client/src/components/editor/feature-viewer.js
@@ -10,7 +10,7 @@ class FeatureViewer extends PureComponent {
     this.bindedOnValueChange = this.onValueChange.bind(this);
     this.bindedOnLineChange = this.onLineChange.bind(this);
 
-    this.buildState(props);
+    this.state = this.buildState(props);
   }
 
   numericField(field) {
@@ -26,15 +26,15 @@ class FeatureViewer extends PureComponent {
   }
 
   componentWillReceiveProps(props) {
-    this.buildState(props);
+    this.setState(this.buildState(props));
   }
 
   buildState(props) {
-    this.state = {fields: {}};
+    const opts = {fields: {}};
 
     const properties = props.feature ? props.feature.properties : null;
 
-    if (!properties) return;
+    if (!properties) return {};
 
     Object.entries(properties).map(entry => {
       const key = entry[0];
@@ -42,8 +42,16 @@ class FeatureViewer extends PureComponent {
 
       if (!this.visibleFields().includes(key)) return;
 
-      this.state.fields[key] = value;
+      opts.fields[key] = value;
     });
+
+    return opts;
+  }
+
+  updateField(key, value) {
+    const newState = {...this.state};
+    newState.fields[key] = value;
+    this.setState(newState);
   }
 
   onValueChange(e) {
@@ -55,8 +63,7 @@ class FeatureViewer extends PureComponent {
 
     if (this.props.onFeatureChange) this.props.onFeatureChange(modifiedFeature, key, value);
 
-    this.state.fields[key] = value;
-    this.forceUpdate;
+    this.updateField(key, value);
   }
 
   onLineChange(e) {

--- a/client/src/components/editor/feature-viewer.js
+++ b/client/src/components/editor/feature-viewer.js
@@ -7,9 +7,6 @@ class FeatureViewer extends PureComponent {
   constructor(props, context) {
     super(props, context);
 
-    this.bindedOnValueChange = this.onValueChange.bind(this);
-    this.bindedOnLineChange = this.onLineChange.bind(this);
-
     this.state = this.buildState(props);
   }
 
@@ -58,13 +55,20 @@ class FeatureViewer extends PureComponent {
     if (this.props.onFeatureChange) this.props.onFeatureChange(modifiedFeature, key, value);
   }
 
-  onLineChange(e) {
-    const newLineUrlName = e.target.value;
-
+  onAddLine(newLine) {
     const modifiedFeature = Object.assign({}, this.props.feature);
-    modifiedFeature.properties['line_url_name'] = newLineUrlName;
+    modifiedFeature.properties.lines.push(newLine);
 
-    if (this.props.onFeatureChange) this.props.onFeatureChange(modifiedFeature, 'line_url_name', newLineUrlName);
+    if (this.props.onFeatureChange) this.props.onFeatureChange(modifiedFeature);
+  }
+
+  onRemoveLine(urlName) {
+    const modifiedFeature = Object.assign({}, this.props.feature);
+
+    const lineIndex = modifiedFeature.properties.lines.findIndex(l => l.line_url_name == urlName);
+    modifiedFeature.properties.lines.splice(lineIndex, 1);
+
+    if (this.props.onFeatureChange) this.props.onFeatureChange(modifiedFeature);
   }
 
   render() {
@@ -80,7 +84,8 @@ class FeatureViewer extends PureComponent {
                     featureLines={this.props.feature.properties.lines}
                     lines={this.props.lines}
                     systems={this.props.systems}
-                    onAddLine={this.onLineChange}
+                    onAddLine={this.onAddLine.bind(this)}
+                    onRemoveLine={this.onRemoveLine.bind(this)}
                   />
                 </td>
               </tr>
@@ -96,7 +101,7 @@ class FeatureViewer extends PureComponent {
                       <input className="c-field"
                              type={this.numericField(key) ? 'number' : 'text'}
                              name={key}
-                             onChange={this.bindedOnValueChange}
+                             onChange={this.onValueChange.bind(this)}
                              value={this.state.fields[key]}/>
                         :
                         this.state.fields[key]

--- a/client/src/components/editor/feature-viewer.js
+++ b/client/src/components/editor/feature-viewer.js
@@ -1,6 +1,8 @@
 import React, {PureComponent} from 'react';
 import Translate from 'react-translate-component';
 
+import FeatureLinesEditor from './feature-viewer/feature-lines-editor';
+
 class FeatureViewer extends PureComponent {
   constructor(props, context) {
     super(props, context);
@@ -74,18 +76,13 @@ class FeatureViewer extends PureComponent {
             <caption className="c-table__caption"><Translate content={`editor.feature_viewer.fields.klasses_id.${properties.klass.toLowerCase()}`} with={{id: properties.id}} /></caption>
             <tbody className="c-table__body">
               <tr className="c-table__row">
-                <td className="c-table__cell"><Translate content="editor.feature_viewer.fields.line" /></td>
-                <td className="c-table__cell">
-                  <select className="c-field u-xsmall" value={this.props.feature.properties.line_url_name} onChange={this.bindedOnLineChange}>
-                    {this.props.systems.map((system) => {
-                      return this.props.lines.filter(line => line.system_id == system.id).map((line) => {
-                        const label = system.name ? `${system.name} - ${line.name}` : line.name;
-                        return (
-                          <option key={`${properties.klass}_${properties.id}_${line.url_name}`} value={line.url_name}>{label}</option>
-                        )
-                       })
-                    })}
-                  </select>
+                <td className="c-table__cell" colSpan="2">
+                  <FeatureLinesEditor
+                    featureLines={this.props.feature.properties.lines}
+                    lines={this.props.lines}
+                    systems={this.props.systems}
+                    onAddLine={this.onLineChange}
+                  />
                 </td>
               </tr>
               { Object.keys(this.state.fields).map((key) => {

--- a/client/src/components/editor/feature-viewer.js
+++ b/client/src/components/editor/feature-viewer.js
@@ -48,12 +48,6 @@ class FeatureViewer extends PureComponent {
     return opts;
   }
 
-  updateField(key, value) {
-    const newState = {...this.state};
-    newState.fields[key] = value;
-    this.setState(newState);
-  }
-
   onValueChange(e) {
     const key = e.target.attributes.name.value;
     const value = e.target.value;
@@ -62,8 +56,6 @@ class FeatureViewer extends PureComponent {
     modifiedFeature.properties[key] = value;
 
     if (this.props.onFeatureChange) this.props.onFeatureChange(modifiedFeature, key, value);
-
-    this.updateField(key, value);
   }
 
   onLineChange(e) {

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -1,0 +1,30 @@
+import React, {PureComponent} from 'react';
+import Translate from 'react-translate-component';
+
+class FeatureLinesEditor extends PureComponent {
+  render() {
+    return (
+      <ul className="c-list c-list--unstyled">
+        {this.props.featureLines.map((l) =>
+          <li key={`own-${l.line_url_name}`}className="c-list__item editor-features-lines-item">{`${l.line} - ${l.system}`}<span className="fa fa-close"></span></li>
+          )}
+        <li className="c-list__item editor-features-lines-item">
+
+          <select className="c-field u-xsmall" onChange={this.props.onAddLine}>
+            <option>Add line</option>
+            {this.props.systems.map((system) => {
+              return this.props.lines.filter(line => line.system_id == system.id).map((line) => {
+                const label = system.name ? `${system.name} - ${line.name}` : line.name;
+                return (
+                  <option key={line.url_name} value={line.url_name}>{label}</option>
+                )
+               })
+            })}
+          </select>
+        </li>
+      </ul>
+    )
+  }
+}
+
+export default FeatureLinesEditor

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -2,21 +2,40 @@ import React, {PureComponent} from 'react';
 import Translate from 'react-translate-component';
 
 class FeatureLinesEditor extends PureComponent {
+  onAddLine(e) {
+    const [line, line_url_name, system] = e.target.value.split(',');
+
+    const newLine = {
+      line: line,
+      line_url_name: line_url_name,
+      system: system
+    }
+
+    this.props.onAddLine(newLine);
+  }
+
+  onRemove(urlName) {
+    this.props.onRemoveLine(urlName);
+  }
+
   render() {
     return (
       <ul className="c-list c-list--unstyled">
         {this.props.featureLines.map((l) =>
-          <li key={`own-${l.line_url_name}`}className="c-list__item editor-features-lines-item">{`${l.line} - ${l.system}`}<span className="fa fa-close"></span></li>
+          <li key={`own-${l.line_url_name}`}className="c-list__item editor-features-lines-item">{`${l.line} - ${l.system}`}<span className="fa fa-close" onClick={() => this.onRemove(l.line_url_name)}></span></li>
           )}
         <li className="c-list__item editor-features-lines-item">
-
-          <select className="c-field u-xsmall" onChange={this.props.onAddLine}>
+          <select className="c-field u-xsmall" onChange={this.onAddLine.bind(this)}>
             <option>Add line</option>
             {this.props.systems.map((system) => {
               return this.props.lines.filter(line => line.system_id == system.id).map((line) => {
                 const label = system.name ? `${system.name} - ${line.name}` : line.name;
+                if (this.props.featureLines.find(l => l.line_url_name == line.url_name)) {
+                  return;
+                }
+
                 return (
-                  <option key={line.url_name} value={line.url_name}>{label}</option>
+                  <option key={line.url_name} value={`${line.name},${line.url_name},${system.name}`}>{label}</option>
                 )
                })
             })}

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -18,27 +18,34 @@ class FeatureLinesEditor extends PureComponent {
     this.props.onRemoveLine(urlName);
   }
 
+  remainingLines() {
+    const lines = [];
+
+    this.props.systems.map((system) => {
+      this.props.lines.filter(line => line.system_id == system.id).map((line) => {
+        if (this.props.featureLines.find(l => l.line_url_name == line.url_name)) return;
+
+        const label = system.name ? `${system.name} - ${line.name}` : line.name;
+
+        lines.push({line: line, system: system, label: label});
+      })
+    });
+
+    return lines;
+  }
+
   render() {
     return (
       <ul className="c-list c-list--unstyled">
-        {this.props.featureLines.map((l) =>
+        {this.props.featureLines.sort((a, b) => a.line.localeCompare(b.line)).map((l) =>
           <li key={`own-${l.line_url_name}`}className="c-list__item editor-features-lines-item">{`${l.line} - ${l.system}`}<span className="fa fa-close" onClick={() => this.onRemove(l.line_url_name)}></span></li>
           )}
         <li className="c-list__item editor-features-lines-item">
           <select className="c-field u-xsmall" onChange={this.onAddLine.bind(this)}>
             <option>Add line</option>
-            {this.props.systems.map((system) => {
-              return this.props.lines.filter(line => line.system_id == system.id).map((line) => {
-                const label = system.name ? `${system.name} - ${line.name}` : line.name;
-                if (this.props.featureLines.find(l => l.line_url_name == line.url_name)) {
-                  return;
-                }
-
-                return (
-                  <option key={line.url_name} value={`${line.name},${line.url_name},${system.name}`}>{label}</option>
-                )
-               })
-            })}
+            {this.remainingLines().map(l =>
+              <option key={l.line.url_name} value={`${l.line.name},${l.line.url_name},${l.system.name}`}>{l.label}</option>
+            )}
           </select>
         </li>
       </ul>

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -42,7 +42,7 @@ class FeatureLinesEditor extends PureComponent {
           )}
         <li className="c-list__item editor-features-lines-item">
           <select className="c-field u-xsmall" onChange={this.onAddLine.bind(this)}>
-            <option>Add line</option>
+            <Translate component="option" content="editor.feature_viewer.add_line"/>
             {this.remainingLines().map(l =>
               <option key={l.line.url_name} value={`${l.line.name},${l.line.url_name},${l.system.name}`}>{l.label}</option>
             )}

--- a/client/src/components/editor/feature-viewer/feature-lines-editor.js
+++ b/client/src/components/editor/feature-viewer/feature-lines-editor.js
@@ -38,7 +38,7 @@ class FeatureLinesEditor extends PureComponent {
     return (
       <ul className="c-list c-list--unstyled">
         {this.props.featureLines.sort((a, b) => a.line.localeCompare(b.line)).map((l) =>
-          <li key={`own-${l.line_url_name}`}className="c-list__item editor-features-lines-item">{`${l.line} - ${l.system}`}<span className="fa fa-close" onClick={() => this.onRemove(l.line_url_name)}></span></li>
+          <li key={`own-${l.line_url_name}`}className="c-list__item editor-features-lines-item">{l.system ? `${l.line} - ${l.system}` : l.line}<span className="fa fa-close" onClick={() => this.onRemove(l.line_url_name)}></span></li>
           )}
         <li className="c-list__item editor-features-lines-item">
           <select className="c-field u-xsmall" onChange={this.onAddLine.bind(this)}>

--- a/client/src/lib/km-info.js
+++ b/client/src/lib/km-info.js
@@ -16,17 +16,13 @@ class KmInfo {
 
     if (!yearInfo) return;
 
-    Object.values(this.lines).map((line) => {
-      if (!yearInfo[line]) return;
+    const sections = Object.values(yearInfo).filter(info => info.lines.some(l => this.lines.includes(l)))
 
-      if (yearInfo[line].operative) {
-        operative += yearInfo[line].operative;
-      }
+    const keys = ['operative', 'under_construction'];
 
-      if (yearInfo[line].under_construction) {
-        underConstruction += yearInfo[line].under_construction;
-      }
-    });
+    [operative, underConstruction] = keys.map(k =>
+      sections.filter(s => s[k] && s[k] > 0).map(s => s[k]).reduce((total, e) => total + e, 0)
+    )
 
     operative = parseInt(operative/1000);
     underConstruction = parseInt(underConstruction/1000);

--- a/client/src/lib/lines-mapper.js
+++ b/client/src/lib/lines-mapper.js
@@ -53,7 +53,21 @@ class LinesMapper extends Mapper {
       ];
     }
 
-    const linesShownFilter = ["in", "line_url_name"].concat(this.linesShown.concat("shared-station"));
+    // The first line_url_name attr is present in all features.
+    // But in shared stations, it's used only for styling purposes.
+    // That's why shared stations have also extra line_url_name attrs: so
+    // they can be filtered by the lines that use that station.
+    const linesShownFilter = [
+      "any",
+      ["in", "line_url_name"].concat(this.linesShown),
+
+      ["in", "line_url_name_1"].concat(this.linesShown),
+      ["in", "line_url_name_2"].concat(this.linesShown),
+      ["in", "line_url_name_3"].concat(this.linesShown),
+      ["in", "line_url_name_4"].concat(this.linesShown),
+      ["in", "line_url_name_5"].concat(this.linesShown)
+    ]
+
     filter.push(linesShownFilter);
 
     return filter;

--- a/client/src/lib/lines-mapper.js
+++ b/client/src/lib/lines-mapper.js
@@ -60,7 +60,6 @@ class LinesMapper extends Mapper {
     const linesShownFilter = [
       "any",
       ["in", "line_url_name"].concat(this.linesShown),
-
       ["in", "line_url_name_1"].concat(this.linesShown),
       ["in", "line_url_name_2"].concat(this.linesShown),
       ["in", "line_url_name_3"].concat(this.linesShown),

--- a/client/src/lib/lines-mapper.js
+++ b/client/src/lib/lines-mapper.js
@@ -53,7 +53,7 @@ class LinesMapper extends Mapper {
       ];
     }
 
-    const linesShownFilter = ["in", "line_url_name"].concat(this.linesShown);
+    const linesShownFilter = ["in", "line_url_name"].concat(this.linesShown.concat("shared-station"));
     filter.push(linesShownFilter);
 
     return filter;

--- a/client/src/lib/mouse-events.js
+++ b/client/src/lib/mouse-events.js
@@ -44,8 +44,16 @@ class MouseEvents {
     this.clickedFeatures = {
       point: point,
       features: features.map((f) => {
-        f.properties.lineColor = this.style.lineColor(f.properties.line_url_name);
-        f.properties.lineLabelColor = this.style.lineLabelFontColor(f.properties.line_url_name);
+        if (f.properties.lines) {
+          f.properties.lines = JSON.parse(f.properties.lines);
+          f.properties.lines.map((l) => {
+            l.lineColor = this.style.lineColor(l.line_url_name);
+            l.lineLabelColor = this.style.lineLabelFontColor(l.line_url_name);
+          });
+        } else {
+          f.properties.lineColor = this.style.lineColor(f.properties.line_url_name);
+          f.properties.lineLabelColor = this.style.lineLabelFontColor(f.properties.line_url_name);
+        }
         return f;
       })
     }

--- a/client/src/lib/style.js
+++ b/client/src/lib/style.js
@@ -49,6 +49,13 @@ class Style {
       delete style["color"];
     }
 
+    if (type === 'sections') {
+      style['line-offset'] = {
+        type: "identity",
+        property: "offset"
+      };
+    }
+
     if (operation == 'opening'){
       const stops = [];
 

--- a/client/src/lib/style.js
+++ b/client/src/lib/style.js
@@ -1,6 +1,6 @@
 class Style {
   constructor(lines) {
-    this.lines = {};
+    this.lines = {'shared-station': '#000000'};
 
     lines.map((line) => {
       this.lines[line.url_name] = line.color;

--- a/client/src/stores/editor-store.js
+++ b/client/src/stores/editor-store.js
@@ -239,7 +239,8 @@ const EditorStore = Object.assign({}, Store, {
       feature.properties.opening = 0;
       feature.properties.buildstart = 0;
       feature.properties.closure = 999999;
-      feature.properties.line_url_name = cityData.lines[0] ? cityData.lines[0].url_name : null;
+      feature.properties.lines = [];
+
       if (klass == 'Station' && !feature.properties.name) feature.properties.name = '';
 
       this.pushFeatureToFeatureCollection(urlName, feature);


### PR DESCRIPTION
Checklist:
- [x] Multiple lines per track
- [x] Station color should be black when there are multiple lines that use it
- [x] Station popup should display multiple lines info
- [x] Fix lines popup of the same track (and see why all of them are getting selected)
- [x] Put `shared-station` string in constant ?
- [x] How to toggle shared-stations ?
- [x] Editor: add more lines to track 
- [x] Editor: add more lines to stations
- [x] Translate "Add line"
- [x] Sort lines alphabetically
- [x] Update tests
- [x] Cache should also consider SectionLine and StationLine
- [x] Check that OSM import works fine
- [x] Check that drawing features works fine
- [x] Fix lengths calculation

After deploy:
- [ ] Fix dataclips

Fixes #85
Fixes #83 
Fixes #82