### PR TITLE
Circle ci improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,18 +11,18 @@ jobs:
             sudo apt-get install curl bash python3
             pip install docker-compose
       - run:
-        name: Install node@8.1.4
-        command: |
-          set +e
-          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-          export NVM_DIR="/opt/circleci/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-          nvm install v8.1.4
-          nvm alias default v8.1.4
+          name: Install node@8.1.4
+          command: |
+            set +e
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm install v8.1.4
+            nvm alias default v8.1.4
 
-          # Each step uses the same `$BASH_ENV`, so need to modify it
-          echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-          echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+            # Each step uses the same `$BASH_ENV`, so need to modify it
+            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+            echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
       - run:
           name: Install yarn
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2
 jobs:
   build:
     machine: true
+      node:
+      version: 8.0.0
     steps:
       - checkout
       - run:
@@ -10,11 +12,6 @@ jobs:
             set -x
             sudo apt-get install curl bash python3
             pip install docker-compose
-      - run:
-          name: Install node
-          command: |
-            curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-            sudo apt-get install -y nodejs
       - run:
           name: Install yarn
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,11 @@ jobs:
           name: Install docker-compose
           command: |
             set -x
-            sudo apt-get install curl curl-dev bash python3 yarn
+            sudo apt-get install curl bash python3
             pip3 install docker-compose
+            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+            echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+            sudo apt-get update && sudo apt-get install yarn
       - run:
           name: Backend tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,33 +11,15 @@ jobs:
             sudo apt-get install curl bash python3
             pip install docker-compose
       - run:
-          name: Install node@8.1.4
-          command: |
-            set +e
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-            export NVM_DIR="/opt/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            nvm install v8.1.4
-            nvm alias default v8.1.4
-
-            # Each step uses the same `$BASH_ENV`, so need to modify it
-            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-            echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-      - run:
-          name: Install yarn
-          command: |
-            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-            sudo apt-get update && sudo apt-get install yarn
-      - run:
           name: Backend tests
           command: |
             set -x
             mv api/config/auth.yml.sample api/config/auth.yml
-            chmod +x tools/test
-            tools/test
+            chmod +x tools/backend_tests
+            tools/backend_tests
       - run:
           name: Frontend tests
           command: |
             set -x
-            yarn && yarn test
+            chmod +x tools/frontend_tests
+            tools/frontend_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
           name: Install docker-compose
           command: |
             set -x
-            apk update && apk add curl curl-dev bash python3 yarn
+            apt-get install curl curl-dev bash python3 yarn
             pip3 install docker-compose
       - run:
           name: Backend tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,14 @@ jobs:
             set -x
             sudo apt-get install curl bash python3
             pip install docker-compose
+      - run:
+          name: Install node
+          command: |
+            curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+      - run:
+          name: Install yarn
+          command: |
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
             sudo apt-get update && sudo apt-get install yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           name: Backend tests
           command: |
             set -x
+            mv api/config/auth.yml.sample api/config/auth.yml
             chmod +x tools/test
             tools/test
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,9 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: docker:17.06.1-ce-git
+    machine: true
     steps:
       - checkout
-      - setup_remote_docker
       - run:
           name: Install docker-compose
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,7 @@
 version: 2
 jobs:
   build:
-    machine:
-      node:
-      version: 8.0.0
+    machine: true
     steps:
       - checkout
       - run:
@@ -12,6 +10,19 @@ jobs:
             set -x
             sudo apt-get install curl bash python3
             pip install docker-compose
+      - run:
+        name: Install node@8.1.4
+        command: |
+          set +e
+          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+          export NVM_DIR="/opt/circleci/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install v8.1.4
+          nvm alias default v8.1.4
+
+          # Each step uses the same `$BASH_ENV`, so need to modify it
+          echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+          echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
       - run:
           name: Install yarn
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    machine: true
+    machine:
       node:
       version: 8.0.0
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
           name: Install docker-compose
           command: |
             set -x
-            apt-get install curl curl-dev bash python3 yarn
+            sudo apt-get install curl curl-dev bash python3 yarn
             pip3 install docker-compose
       - run:
           name: Backend tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           command: |
             set -x
             sudo apt-get install curl bash python3
-            pip3 install docker-compose
+            pip install docker-compose
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
             sudo apt-get update && sudo apt-get install yarn

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -28,5 +28,5 @@ RUN \
 
 ADD . /app/
 
-ENTRYPOINT ["sh", "/app/entrypoint.sh"]
+ENTRYPOINT ["sh", "entrypoint.sh"]
 CMD ["bundle", "exec", "rake", "test"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -28,5 +28,5 @@ RUN \
 
 ADD . /app/
 
-ENTRYPOINT ["sh", "entrypoint.sh"]
+ENTRYPOINT ["sh", "/app/entrypoint.sh"]
 CMD ["bundle", "exec", "rake", "test"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -28,5 +28,5 @@ RUN \
 
 ADD . /app/
 
-ENTRYPOINT ["sh", "entrypoint.sh"]
+ENTRYPOINT ["sh", "./entrypoint.sh"]
 CMD ["bundle", "exec", "rake", "test"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -29,4 +29,3 @@ RUN \
 ADD . /app/
 
 ENTRYPOINT ["sh", "entrypoint.sh"]
-CMD ["bundle", "exec", "rake", "test"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -28,5 +28,5 @@ RUN \
 
 ADD . /app/
 
-ENTRYPOINT ["bash", "entrypoint.sh"]
+ENTRYPOINT ["sh", "entrypoint.sh"]
 CMD ["bundle", "exec", "rake", "test"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -28,5 +28,5 @@ RUN \
 
 ADD . /app/
 
-ENTRYPOINT ["sh", "entrypoint.sh"]
+ENTRYPOINT ["bash", "entrypoint.sh"]
 CMD ["bundle", "exec", "rake", "test"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -28,5 +28,5 @@ RUN \
 
 ADD . /app/
 
-ENTRYPOINT ["sh", "./entrypoint.sh"]
+ENTRYPOINT ["sh", "entrypoint.sh"]
 CMD ["bundle", "exec", "rake", "test"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the source code of [citylines.co](http://www.citylines.co), a collaborat
 
 ![](https://user-images.githubusercontent.com/6061036/40272543-53a12d90-5b85-11e8-88a9-787f257fd243.png)
 
-Development
+Development [![CircleCI](https://circleci.com/gh/BrunoSalerno/citylines/tree/master.svg?style=svg)](https://circleci.com/gh/BrunoSalerno/citylines/tree/master)
 ===========
 
 This repo contains the client and the API, which are built with the following technologies:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Frontend
 ------
 Run
 ```
-tools/test_frontend
+yarn test
 ```
 
 Contact

--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ API
 ---
 Run
 ```
-tools/test
+tools/backend_tests
 ```
 
 Frontend
 ------
 Run
 ```
-yarn test
+tools/frontend_tests
 ```
 
 Contact

--- a/docker-compose.test.backend.yml
+++ b/docker-compose.test.backend.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  web_test:
+    links:
+      - db_test:db.local
+    environment:
+      - RACK_ENV=test
+      - DATABASE_URL=postgres://citylines_test:citylines_test@db.local/citylines_test
+    volumes:
+      - .:/app
+    depends_on:
+      - db_test
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    command: bundle exec rake test
+  db_test:
+    image: "mdillon/postgis"
+    environment:
+      - POSTGRES_DB=citylines_test
+      - POSTGRES_USER=citylines_test
+      - POSTGRES_PASSWORD=citylines_test
+    volumes:
+      - ./dumps:/dumps:ro

--- a/docker-compose.test.frontend.yml
+++ b/docker-compose.test.frontend.yml
@@ -13,6 +13,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.test
+    command: bash -c 'yarn && yarn test'
   db_test:
     image: "mdillon/postgis"
     environment:

--- a/tools/backend_tests
+++ b/tools/backend_tests
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose -f docker-compose.test.backend.yml up --build --exit-code-from web_test

--- a/tools/frontend_tests
+++ b/tools/frontend_tests
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose -f docker-compose.test.frontend.yml up --build --exit-code-from web_test

--- a/tools/test
+++ b/tools/test
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker-compose -f docker-compose.test.yml up --build --exit-code-from web_test

--- a/tools/test_frontend
+++ b/tools/test_frontend
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-docker exec citylines_web_1 yarn test


### PR DESCRIPTION
- [x] Use docker-compose to run frontend tests (and restore the `tools/tests_frontend` script). Maybe one Dockerfile and 3 docker-compose files (one for dev, one for backend tests, and one for frontend tests)
- [x] Add the badge in the README file