### PR TITLE
Enforce removal of Mapbox objects

### DIFF
--- a/client/__tests__/lib/lines_mapper_test.js
+++ b/client/__tests__/lib/lines_mapper_test.js
@@ -1,0 +1,42 @@
+import LinesMapper from '../../src/lib/lines-mapper';
+import Style from '../../src/lib/style';
+
+describe("LinesMapper", () => {
+  describe("sources", () => {
+    it("should return the expected sources and lines", () => {
+      const linesMapper = new LinesMapper({
+        urlName:'test-city',
+        style: new Style([])
+      });
+
+      linesMapper.updateLayers();
+      const sources = linesMapper.sources;
+
+      expect(sources.length).toEqual(2);
+
+      // Sections
+      expect(sources[0].name).toEqual('sections_source');
+      expect(sources[0].data).toEqual('/api/test-city/source/sections');
+      expect(sources[0].layers.map(l => l.id)).
+        toEqual(['sections_buildstart', 'sections_opening', 'sections_hover']);
+      expect([...new Set(sources[0].layers.map(l => l.source))]).toEqual(['sections_source']);
+      expect([...new Set(sources[0].layers.map(l => l.type))]).toEqual(['line']);
+      sources[0].layers.map(layer => {
+        expect(layer.paint).toBeTruthy();
+        expect(layer.filter).toBeTruthy();
+      });
+
+      // Stations
+      expect(sources[1].name).toEqual('stations_source');
+      expect(sources[1].data).toEqual('/api/test-city/source/stations');
+      expect(sources[1].layers.map(l => l.id)).
+        toEqual(['stations_buildstart', 'stations_opening', 'stations_hover', 'stations_inner_layer']);
+      expect([...new Set(sources[1].layers.map(l => l.source))]).toEqual(['stations_source']);
+      expect([...new Set(sources[1].layers.map(l => l.type))]).toEqual(['circle']);
+      sources[1].layers.map(layer => {
+        expect(layer.paint).toBeTruthy();
+        expect(layer.filter).toBeTruthy();
+      });
+    });
+  })
+});

--- a/client/src/components/city-comparison.js
+++ b/client/src/components/city-comparison.js
@@ -287,17 +287,7 @@ class CityComparison extends PureComponent {
                   key={source.name}
                   name={source.name}
                   data={source.data}
-                />
-              )
-            }) }
-            { state.layers && state.layers.map((layer) => { return (
-                <Layer
-                  key={layer.id}
-                  id={layer.id}
-                  source={layer.source}
-                  type={layer.type}
-                  paint={layer.paint}
-                  filter={layer.filter}
+                  layers={source.layers}
                 />
               )
             }) }

--- a/client/src/components/city-comparison.js
+++ b/client/src/components/city-comparison.js
@@ -1,7 +1,7 @@
 import React, {PureComponent} from 'react';
 import {browserHistory} from 'react-router';
 
-import {Map, Source, Layer, Popup, Draw} from './map';
+import {Map, Source, Popup, Draw} from './map';
 import Tags from './tags';
 
 import Translate from 'react-translate-component';

--- a/client/src/components/city-comparison.js
+++ b/client/src/components/city-comparison.js
@@ -282,15 +282,14 @@ class CityComparison extends PureComponent {
             onMouseClick={(point, features) => {CityViewStore.clickFeatures(urlName, point, features)}}
             onMove={this.handleMapMove.bind(this)}
             disableMouseEvents={state.playing} >
-            { state.sources && state.sources.map((source) => { return (
-                <Source
-                  key={source.name}
-                  name={source.name}
-                  data={source.data}
-                  layers={source.layers}
-                />
-              )
-            }) }
+            { state.sources && state.sources.map((source) =>
+              <Source
+                key={source.name}
+                name={source.name}
+                data={source.data}
+                layers={source.layers}
+              />
+            ) }
             { state.clickedFeatures && (<Popup
               point={state.clickedFeatures.point}
               onClose={() => {CityViewStore.unClickFeatures(urlName)}}>

--- a/client/src/components/city.js
+++ b/client/src/components/city.js
@@ -193,17 +193,7 @@ class City extends PureComponent {
                   key={source.name}
                   name={source.name}
                   data={source.data}
-                />
-              )
-            }) }
-            { this.state.layers && this.state.layers.map((layer) => { return (
-                <Layer
-                  key={layer.id}
-                  id={layer.id}
-                  source={layer.source}
-                  type={layer.type}
-                  paint={layer.paint}
-                  filter={layer.filter}
+                  layers={source.layers}
                 />
               )
             }) }

--- a/client/src/components/city.js
+++ b/client/src/components/city.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import CutLineMode from 'mapbox-gl-draw-cut-line-mode';
 
 import {PanelHeader, PanelBody} from './panel';
-import {Map, Source, Layer, Popup, Draw} from './map';
+import {Map, Source, Popup, Draw} from './map';
 import Tags from './tags';
 
 import Translate from 'react-translate-component';

--- a/client/src/components/city.js
+++ b/client/src/components/city.js
@@ -188,15 +188,14 @@ class City extends PureComponent {
             onMouseMove={this.bindedOnMouseMove}
             onMouseClick={this.bindedOnMouseClick}
             disableMouseEvents={this.state.playing} >
-            { this.state.sources && this.state.sources.map((source) => { return (
-                <Source
-                  key={source.name}
-                  name={source.name}
-                  data={source.data}
-                  layers={source.layers}
-                />
-              )
-            }) }
+            { this.state.sources && this.state.sources.map((source) =>
+              <Source
+                key={source.name}
+                name={source.name}
+                data={source.data}
+                layers={source.layers}
+              />
+            ) }
             { this.state.clickedFeatures && (<Popup
               point={this.state.clickedFeatures.point}
               onClose={this.bindedOnPopupClose}>

--- a/client/src/components/map.js
+++ b/client/src/components/map.js
@@ -82,7 +82,6 @@ class Map extends Component {
   componentWillUnmount() {
     this.map.remove();
     this.map.removed = true;
-    console.log("Map removed");
   }
 
   componentWillReceiveProps(nextProps) {
@@ -119,23 +118,19 @@ Map.childContextTypes = {
 
 class Source extends Component {
   componentWillMount(){
-    console.log("Mount source:", this.props.name);
     this.map = this.context.map;
     this.load();
   }
 
   componentWillUnmount(){
     if (this.map.removed) {
-      console.log("Map already removed from source:", this.props.name);
       return;
     }
 
-    console.log("Remove all layers from source:", this.props.name);
     this.props.layers.map(layer =>
       this.map.removeLayer(layer.id)
     );
 
-    console.log("Unmount source:", this.props.name);
     this.map.removeSource(this.props.name);
   }
 
@@ -172,7 +167,6 @@ Source.contextTypes = {
 
 class Layer extends Component {
   componentDidMount(){
-    console.log("Mount layer:", this.props.id);
     this.map = this.props.map;
     this.load();
   }

--- a/client/src/components/map.js
+++ b/client/src/components/map.js
@@ -352,4 +352,4 @@ Draw.contextTypes = {
   map: PropTypes.object
 }
 
-export {Map, Source, Layer, Popup, Draw};
+export {Map, Source, Popup, Draw};

--- a/client/src/components/map.js
+++ b/client/src/components/map.js
@@ -79,6 +79,12 @@ class Map extends Component {
     }
   }
 
+  componentWillUnmount() {
+    this.map.remove();
+    this.map.removed = true;
+    console.log("Map removed");
+  }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.center && !this.map) {
       this.setMap(nextProps);
@@ -119,6 +125,11 @@ class Source extends Component {
   }
 
   componentWillUnmount(){
+    if (this.map.removed) {
+      console.log("Map already removed from source:", this.props.name);
+      return;
+    }
+
     console.log("Remove all layers from source:", this.props.name);
     this.props.layers.map(layer =>
       this.map.removeLayer(layer.id)
@@ -249,14 +260,16 @@ class Draw extends Component {
   }
 
   componentWillUnmount() {
-    this.map.off('draw.selectionchange', this.bindedOnSelectionChange);
-    this.map.off('draw.update', this.bindedOnUpdate);
-    this.map.off('draw.create', this.bindedOnCreate);
-    this.map.off('draw.delete', this.bindedOnDelete);
-    this.map.off('draw.modechange', this.bindedOnModeChange);
+    if (!this.map.removed) {
+      this.map.off('draw.selectionchange', this.bindedOnSelectionChange);
+      this.map.off('draw.update', this.bindedOnUpdate);
+      this.map.off('draw.create', this.bindedOnCreate);
+      this.map.off('draw.delete', this.bindedOnDelete);
+      this.map.off('draw.modechange', this.bindedOnModeChange);
 
-    this.draw.deleteAll();
-    this.map.removeControl(this.draw)
+      this.draw.deleteAll();
+      this.map.removeControl(this.draw);
+    }
     delete this.draw;
   }
 

--- a/client/src/components/map.js
+++ b/client/src/components/map.js
@@ -80,8 +80,10 @@ class Map extends Component {
   }
 
   componentWillUnmount() {
-    this.map.remove();
-    this.map.removed = true;
+    if (this.map) {
+      this.map.remove();
+      this.map.removed = true;
+    }
   }
 
   componentWillReceiveProps(nextProps) {

--- a/client/src/components/map.js
+++ b/client/src/components/map.js
@@ -133,7 +133,22 @@ class Source extends Component {
   }
 
   render() {
-    return null;
+    return (
+      <div>
+      { this.props.layers && this.props.layers.map(layer =>
+        <Layer
+        key={layer.id}
+        id={layer.id}
+        map={this.map}
+        source={this.props.name}
+        type={layer.type}
+        paint={layer.paint}
+        filter={layer.filter}
+        />
+      )
+      }
+      </div>
+    )
   }
 }
 
@@ -143,7 +158,7 @@ Source.contextTypes = {
 
 class Layer extends Component {
   componentDidMount(){
-    this.map = this.context.map;
+    this.map = this.props.map;
     this.load();
   }
 
@@ -175,10 +190,6 @@ class Layer extends Component {
   render() {
     return null;
   }
-}
-
-Layer.contextTypes = {
-  map: PropTypes.object
 }
 
 class Popup extends Component {

--- a/client/src/components/map.js
+++ b/client/src/components/map.js
@@ -112,12 +112,19 @@ Map.childContextTypes = {
 }
 
 class Source extends Component {
-  componentDidMount(){
+  componentWillMount(){
+    console.log("Mount source:", this.props.name);
     this.map = this.context.map;
     this.load();
   }
 
   componentWillUnmount(){
+    console.log("Remove all layers from source:", this.props.name);
+    this.props.layers.map(layer =>
+      this.map.removeLayer(layer.id)
+    );
+
+    console.log("Unmount source:", this.props.name);
     this.map.removeSource(this.props.name);
   }
 
@@ -128,10 +135,6 @@ class Source extends Component {
     });
   }
 
-  shouldComponentUpdate() {
-    return false;
-  }
-
   render() {
     return (
       <div>
@@ -139,7 +142,7 @@ class Source extends Component {
         <Layer
         key={layer.id}
         id={layer.id}
-        map={this.map}
+        map={this.context.map}
         source={this.props.name}
         type={layer.type}
         paint={layer.paint}
@@ -158,12 +161,9 @@ Source.contextTypes = {
 
 class Layer extends Component {
   componentDidMount(){
+    console.log("Mount layer:", this.props.id);
     this.map = this.props.map;
     this.load();
-  }
-
-  componentWillUnmount(){
-    this.map.removeLayer(this.props.id);
   }
 
   componentWillReceiveProps(nextProps, nextContext) {

--- a/client/src/lib/lines-mapper.js
+++ b/client/src/lib/lines-mapper.js
@@ -9,17 +9,17 @@ class LinesMapper extends Mapper {
     this.currentYear = null;
 
     this.layerNames = {
-      sections: {
-        BUILDSTART: 'sections_buildstart',
-        OPENGING: 'sections_opening',
-        HOVER: 'sections_hover'
-      },
-      stations: {
-        BUILDSTART: 'stations_buildstart',
-        OPENGING: 'stations_opening',
-        HOVER: 'stations_hover',
-        INNER_LAYER: 'stations_inner_layer'
-      }
+      sections: [
+        'sections_buildstart',
+        'sections_opening',
+        'sections_hover'
+      ],
+      stations: [
+        'stations_buildstart',
+        'stations_opening',
+        'stations_hover',
+        'stations_inner_layer'
+      ]
     };
   }
 

--- a/client/src/lib/mapper.js
+++ b/client/src/lib/mapper.js
@@ -8,13 +8,9 @@ class Mapper {
     this.filterCache = {};
 
     this.linesShown = [];
-    this.layers = [];
-    this.sources = ['sections', 'stations'].map((type) => {
-      return {
-        name: `${type}_source`,
-        data: `/api/${this.urlName}/source/${type}`
-      }
-    });
+
+    this.SOURCE_TYPES = ['sections', 'stations'];
+    this.sources = [];
 
     this.currentHoverId = {sections: ['none'], stations: ['none']};
 
@@ -22,22 +18,22 @@ class Mapper {
     // Set this.layerNames;
   }
 
-  filter(layer) {
-    // To implement
-  }
-
   updateLayers() {
-    const layers = [];
-
-    ['sections', 'stations'].map((type) => {
-      Object.values(this.layerNames[type]).map((layer) => {
+    this.sources = this.SOURCE_TYPES.map(type => {
         const sourceName = `${type}_source`;
         const featureType = type === 'sections' ? 'line' : 'circle';
-        layers.push(this.layer(sourceName, layer, featureType));
-      });
-    });
 
-    this.layers = layers;
+        return {
+          name: sourceName,
+          layers: this.layerNames[type].map(layerName => this.layer(sourceName, layerName, featureType)),
+          data: `/api/${this.urlName}/source/${type}`
+        };
+      }
+    )
+  }
+
+  filter(layer) {
+    // To implement
   }
 
   layer(sourceName, layerName, featureType) {

--- a/client/src/lib/mouse-events.js
+++ b/client/src/lib/mouse-events.js
@@ -69,7 +69,7 @@ class MouseEvents {
     const layers = [];
     Object.values(this.mappers).map((mapper) => {
       Object.values(mapper.layerNames).map((type) => {
-        Object.values(type).map((layer) => {
+        type.map((layer) => {
           if (!layer.includes('hover') && !layer.includes('inner')) {
             layers.push(layer);
           }

--- a/client/src/stores/city-view-store.js
+++ b/client/src/stores/city-view-store.js
@@ -91,7 +91,6 @@ const CityViewStore = Object.assign({}, Store, {
       transportModes: cityData.transport_modes,
       showTransportModes: cityData.showTransportModes || false,
       sources: cityData.linesMapper ? cityData.linesMapper.sources : [],
-      layers: cityData.linesMapper ? cityData.linesMapper.layers : [],
       linesShown: cityData.linesMapper ? cityData.linesMapper.linesShown.slice() : [],
       years: cityData.years,
       currentYear: cityData.timeline ? cityData.timeline.years.current : null,


### PR DESCRIPTION
This PR fixes two possible memory leaks: a) previously, layers and sources unmount were not coordinated. Now everything is done from the Source element. b) the method map#remove wasn't being called.